### PR TITLE
Feature/ignoreable exceptions

### DIFF
--- a/awaitility/src/main/java/com/jayway/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/Awaitility.java
@@ -125,6 +125,11 @@ public class Awaitility {
     private static volatile boolean defaultCatchUncaughtExceptions = true;
 
     /**
+     * Ignore caught exceptions by default?
+     */
+    private static boolean defaultIgnoreExceptions;
+
+    /**
      * Default listener of condition evaluation results.
      */
     private static volatile ConditionEvaluationListener defaultConditionEvaluationListener = null;
@@ -148,6 +153,13 @@ public class Awaitility {
     }
 
     /**
+     * Instruct Awaitility to ignore caught or uncaught exceptions during condition evaluation.
+     * Exceptions will be treated as evaluating to <code>false</code>. Your test will not fail
+     * upon an exception, unless it times out.
+     */
+    public static void ignoreExceptionsByDefault() { defaultIgnoreExceptions = true; }
+
+    /**
      * Reset the timeout, poll interval, poll delay, uncaught exception handling
      * to their default values:
      * <p>&nbsp;</p>
@@ -156,6 +168,7 @@ public class Awaitility {
      * <li>poll interval - 100 milliseconds</li>
      * <li>poll delay - 100 milliseconds</li>
      * <li>Catch all uncaught exceptions - true</li>
+     * <li>Do not ignore caught exceptions</li>
      * <li>Don't handle condition evaluation results</li>
      * </ul>
      */
@@ -165,6 +178,7 @@ public class Awaitility {
         defaultTimeout = Duration.TEN_SECONDS;
         defaultCatchUncaughtExceptions = true;
         defaultConditionEvaluationListener = null;
+        defaultIgnoreExceptions = false;
         Thread.setDefaultUncaughtExceptionHandler(null);
         MethodCallRecorder.reset();
     }
@@ -189,7 +203,7 @@ public class Awaitility {
      */
     public static ConditionFactory await(String alias) {
         return new ConditionFactory(alias, defaultTimeout, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultConditionEvaluationListener);
+                defaultCatchUncaughtExceptions, defaultIgnoreExceptions, defaultConditionEvaluationListener);
     }
 
     /**
@@ -200,7 +214,7 @@ public class Awaitility {
      * @return the condition factory
      */
     public static ConditionFactory catchUncaughtExceptions() {
-        return new ConditionFactory(defaultTimeout, defaultPollInterval, defaultPollDelay, true);
+        return new ConditionFactory(defaultTimeout, defaultPollInterval, defaultPollDelay, true, defaultIgnoreExceptions);
     }
 
     /**
@@ -210,7 +224,7 @@ public class Awaitility {
      * @return the condition factory
      */
     public static ConditionFactory dontCatchUncaughtExceptions() {
-        return new ConditionFactory(defaultTimeout, defaultPollInterval, defaultPollDelay, false);
+        return new ConditionFactory(defaultTimeout, defaultPollInterval, defaultPollDelay, false, defaultIgnoreExceptions);
     }
 
     /**
@@ -224,7 +238,7 @@ public class Awaitility {
      */
     public static ConditionFactory with() {
         return new ConditionFactory(defaultTimeout, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions, defaultConditionEvaluationListener);
+                defaultCatchUncaughtExceptions, defaultIgnoreExceptions, defaultConditionEvaluationListener);
     }
 
     /**
@@ -238,7 +252,7 @@ public class Awaitility {
      */
     public static ConditionFactory given() {
         return new ConditionFactory(defaultTimeout, defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions);
+                defaultCatchUncaughtExceptions, defaultIgnoreExceptions);
     }
 
     /**
@@ -249,7 +263,8 @@ public class Awaitility {
      * @return the condition factory
      */
     public static ConditionFactory waitAtMost(Duration timeout) {
-        return new ConditionFactory(timeout, defaultPollInterval, defaultPollDelay, defaultCatchUncaughtExceptions);
+        return new ConditionFactory(timeout, defaultPollInterval, defaultPollDelay, defaultCatchUncaughtExceptions,
+                defaultIgnoreExceptions);
     }
 
     /**
@@ -262,7 +277,7 @@ public class Awaitility {
      */
     public static ConditionFactory waitAtMost(long value, TimeUnit unit) {
         return new ConditionFactory(new Duration(value, unit), defaultPollInterval, defaultPollDelay,
-                defaultCatchUncaughtExceptions);
+                defaultCatchUncaughtExceptions, defaultIgnoreExceptions);
     }
 
     /**

--- a/awaitility/src/main/java/com/jayway/awaitility/core/ConditionAwaiter.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/ConditionAwaiter.java
@@ -36,7 +36,7 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
      * @param conditionSettings a {@link com.jayway.awaitility.core.ConditionSettings} object.
      */
     public ConditionAwaiter(final Callable<Boolean> condition,
-                            ConditionSettings conditionSettings) {
+                            final ConditionSettings conditionSettings) {
         if (condition == null) {
             throw new IllegalArgumentException("You must specify a condition (was null).");
         }
@@ -55,8 +55,10 @@ abstract class ConditionAwaiter implements UncaughtExceptionHandler {
                         latch.countDown();
                     }
                 } catch (Exception e) {
-                    throwable = e;
-                    latch.countDown();
+                    if (!conditionSettings.shouldExceptionsBeIgnored()) {
+                        throwable = e;
+                        latch.countDown();
+                    }
                 }
             }
         };

--- a/awaitility/src/main/java/com/jayway/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/ConditionFactory.java
@@ -79,25 +79,12 @@ public class ConditionFactory {
      * @param timeout                 the timeout
      * @param pollInterval            the poll interval
      * @param pollDelay               The poll delay
-     * @param catchUncaughtExceptions the catch uncaught exceptions
-     */
-    public ConditionFactory(String alias, Duration timeout, Duration pollInterval, Duration pollDelay,
-                            boolean catchUncaughtExceptions, ConditionEvaluationListener conditionEvaluationListener) {
-        this(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener, false);
-    }
-
-    /**
-     * Instantiates a new condition factory.
-     *
-     * @param alias                   the alias
-     * @param timeout                 the timeout
-     * @param pollInterval            the poll interval
-     * @param pollDelay               The poll delay
-     * @param catchUncaughtExceptions the catch uncaught exceptions
      * @param ignoreExceptions        the ignore exceptions
+     * @param catchUncaughtExceptions the catch uncaught exceptions
      */
     public ConditionFactory(String alias, Duration timeout, Duration pollInterval, Duration pollDelay,
-                            boolean catchUncaughtExceptions, ConditionEvaluationListener conditionEvaluationListener, boolean ignoreExceptions) {
+            boolean catchUncaughtExceptions, boolean ignoreExceptions,
+            ConditionEvaluationListener conditionEvaluationListener) {
         if (pollInterval == null) {
             throw new IllegalArgumentException("pollInterval cannot be null");
         }
@@ -132,10 +119,12 @@ public class ConditionFactory {
      * @param timeout                 the timeout
      * @param pollInterval            the poll interval
      * @param pollDelay               The delay before the polling starts
+     * @param ignoreExceptions        the ignore exceptions
      * @param catchUncaughtExceptions the catch uncaught exceptions
      */
-    public ConditionFactory(Duration timeout, Duration pollInterval, Duration pollDelay, boolean catchUncaughtExceptions) {
-        this(null, timeout, pollInterval, pollDelay, catchUncaughtExceptions, null);
+    public ConditionFactory(Duration timeout, Duration pollInterval, Duration pollDelay, boolean catchUncaughtExceptions,
+                            boolean ignoreExceptions) {
+        this(null, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions, null);
     }
 
     /**
@@ -144,10 +133,14 @@ public class ConditionFactory {
      * @param timeout                 the timeout
      * @param pollInterval            the poll interval
      * @param pollDelay               The delay before the polling starts
+     * @param ignoreExceptions        the ignore exceptions
      * @param catchUncaughtExceptions the catch uncaught exceptions
      */
-    public ConditionFactory(Duration timeout, Duration pollInterval, Duration pollDelay, boolean catchUncaughtExceptions, ConditionEvaluationListener conditionEvaluationListener) {
-        this(null, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+    public ConditionFactory(Duration timeout, Duration pollInterval, Duration pollDelay,
+                            boolean catchUncaughtExceptions, boolean ignoreExceptions,
+                            ConditionEvaluationListener conditionEvaluationListener) {
+        this(null, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -157,7 +150,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory conditionEvaluationListener(ConditionEvaluationListener conditionEvaluationListener) {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -167,7 +161,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory timeout(Duration timeout) {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -177,7 +172,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory atMost(Duration timeout) {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -188,7 +184,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory forever() {
-        return new ConditionFactory(alias, Duration.FOREVER, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, Duration.FOREVER, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -207,7 +204,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory pollInterval(Duration pollInterval) {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -219,7 +217,7 @@ public class ConditionFactory {
      */
     public ConditionFactory timeout(long timeout, TimeUnit unit) {
         return new ConditionFactory(alias, new Duration(timeout, unit), pollInterval, pollDelay,
-                catchUncaughtExceptions, conditionEvaluationListener);
+                catchUncaughtExceptions, ignoreExceptions, conditionEvaluationListener);
     }
 
     /**
@@ -233,7 +231,7 @@ public class ConditionFactory {
      */
     public ConditionFactory pollDelay(long delay, TimeUnit unit) {
         return new ConditionFactory(alias, this.timeout, pollInterval, new Duration(delay, unit),
-                catchUncaughtExceptions, conditionEvaluationListener);
+                catchUncaughtExceptions, ignoreExceptions, conditionEvaluationListener);
     }
 
     /**
@@ -245,7 +243,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory pollDelay(Duration pollDelay) {
-        return new ConditionFactory(alias, this.timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, this.timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -257,7 +256,7 @@ public class ConditionFactory {
      */
     public ConditionFactory atMost(long timeout, TimeUnit unit) {
         return new ConditionFactory(alias, new Duration(timeout, unit), pollInterval, pollDelay,
-                catchUncaughtExceptions, conditionEvaluationListener);
+                catchUncaughtExceptions, ignoreExceptions,  conditionEvaluationListener);
     }
 
     /**
@@ -277,7 +276,7 @@ public class ConditionFactory {
      */
     public ConditionFactory pollInterval(long pollInterval, TimeUnit unit) {
         return new ConditionFactory(alias, timeout, new Duration(pollInterval, unit), pollDelay,
-                catchUncaughtExceptions, conditionEvaluationListener);
+                catchUncaughtExceptions, ignoreExceptions, conditionEvaluationListener);
     }
 
     /**
@@ -289,20 +288,21 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory catchUncaughtExceptions() {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, true, conditionEvaluationListener);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, true, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
      * Instruct Awaitility to ignore exceptions, both caught and uncaught, that
-     * occur during evaluation. This is useful in situations where the evaluated
+     * occur during evaluation. Exceptions will be treated as evaluating to
+     * <code>false</code>. This is useful in situations where the evaluated
      * conditions may temporarily throw exceptions.
-     * <p>
-     * <em>This effectively rules out the effect of {@link #catchUncaughtExceptions}.</em>
      *
      * @return the condition factory.
      */
     public ConditionFactory ignoreExceptions() {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, true, conditionEvaluationListener, true);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, true,
+                conditionEvaluationListener);
     }
 
     /**
@@ -326,7 +326,8 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory await(String alias) {
-        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener);
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, ignoreExceptions,
+                conditionEvaluationListener);
     }
 
     /**
@@ -376,7 +377,7 @@ public class ConditionFactory {
      * @return the condition factory
      */
     public ConditionFactory dontCatchUncaughtExceptions() {
-        return new ConditionFactory(timeout, pollInterval, pollDelay, false);
+        return new ConditionFactory(timeout, pollInterval, pollDelay, false, ignoreExceptions);
     }
 
     /**

--- a/awaitility/src/main/java/com/jayway/awaitility/core/ConditionFactory.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/ConditionFactory.java
@@ -52,6 +52,11 @@ public class ConditionFactory {
     private final boolean catchUncaughtExceptions;
 
     /**
+     * The ignore exceptions.
+     */
+    private final boolean ignoreExceptions;
+
+    /**
      * The alias.
      */
     private final String alias;
@@ -78,6 +83,21 @@ public class ConditionFactory {
      */
     public ConditionFactory(String alias, Duration timeout, Duration pollInterval, Duration pollDelay,
                             boolean catchUncaughtExceptions, ConditionEvaluationListener conditionEvaluationListener) {
+        this(alias, timeout, pollInterval, pollDelay, catchUncaughtExceptions, conditionEvaluationListener, false);
+    }
+
+    /**
+     * Instantiates a new condition factory.
+     *
+     * @param alias                   the alias
+     * @param timeout                 the timeout
+     * @param pollInterval            the poll interval
+     * @param pollDelay               The poll delay
+     * @param catchUncaughtExceptions the catch uncaught exceptions
+     * @param ignoreExceptions        the ignore exceptions
+     */
+    public ConditionFactory(String alias, Duration timeout, Duration pollInterval, Duration pollDelay,
+                            boolean catchUncaughtExceptions, ConditionEvaluationListener conditionEvaluationListener, boolean ignoreExceptions) {
         if (pollInterval == null) {
             throw new IllegalArgumentException("pollInterval cannot be null");
         }
@@ -103,6 +123,7 @@ public class ConditionFactory {
         this.catchUncaughtExceptions = catchUncaughtExceptions;
         this.pollDelay = pollDelay;
         this.conditionEvaluationListener = conditionEvaluationListener;
+        this.ignoreExceptions = ignoreExceptions;
     }
 
     /**
@@ -269,6 +290,19 @@ public class ConditionFactory {
      */
     public ConditionFactory catchUncaughtExceptions() {
         return new ConditionFactory(alias, timeout, pollInterval, pollDelay, true, conditionEvaluationListener);
+    }
+
+    /**
+     * Instruct Awaitility to ignore exceptions, both caught and uncaught, that
+     * occur during evaluation. This is useful in situations where the evaluated
+     * conditions may temporarily throw exceptions.
+     * <p>
+     * <em>This effectively rules out the effect of {@link #catchUncaughtExceptions}.</em>
+     *
+     * @return the condition factory.
+     */
+    public ConditionFactory ignoreExceptions() {
+        return new ConditionFactory(alias, timeout, pollInterval, pollDelay, true, conditionEvaluationListener, true);
     }
 
     /**
@@ -583,7 +617,8 @@ public class ConditionFactory {
     }
 
     private ConditionSettings generateConditionSettings() {
-        return new ConditionSettings(alias, catchUncaughtExceptions, timeout, pollInterval, pollDelay, conditionEvaluationListener);
+        return new ConditionSettings(alias, catchUncaughtExceptions, timeout, pollInterval, pollDelay, conditionEvaluationListener,
+                ignoreExceptions);
     }
 
     private <T> T until(Condition<T> condition) {

--- a/awaitility/src/main/java/com/jayway/awaitility/core/ConditionSettings.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/ConditionSettings.java
@@ -25,6 +25,7 @@ class ConditionSettings {
     private final Duration pollInterval;
     private final Duration pollDelay;
     private final boolean catchUncaughtExceptions;
+    private final boolean ignoreExceptions;
     private final ConditionEvaluationListener conditionEvaluationListener;
 
     /**
@@ -36,9 +37,11 @@ class ConditionSettings {
      * @param pollInterval                a {@link com.jayway.awaitility.Duration} object.
      * @param pollDelay                   a {@link com.jayway.awaitility.Duration} object.
      * @param conditionEvaluationListener a {@link ConditionEvaluationListener} object.
+     * @param ignoreExceptions            a boolean.
      */
     public ConditionSettings(String alias, boolean catchUncaughtExceptions, Duration maxWaitTime,
-                             Duration pollInterval, Duration pollDelay, ConditionEvaluationListener conditionEvaluationListener) {
+                             Duration pollInterval, Duration pollDelay, ConditionEvaluationListener conditionEvaluationListener,
+                             boolean ignoreExceptions) {
         if (maxWaitTime == null) {
             throw new IllegalArgumentException("You must specify a maximum waiting time (was null).");
         }
@@ -54,6 +57,7 @@ class ConditionSettings {
         this.pollDelay = pollDelay == SAME_AS_POLL_INTERVAL ? pollInterval : pollDelay;
         this.catchUncaughtExceptions = catchUncaughtExceptions;
         this.conditionEvaluationListener = conditionEvaluationListener;
+        this.ignoreExceptions = ignoreExceptions;
     }
 
     /**
@@ -119,4 +123,12 @@ class ConditionSettings {
         return conditionEvaluationListener;
     }
 
+    /**
+     * <p>Getter for the field <code>ignoreExceptions</code></p>
+     *
+     * @return a boolean.
+     */
+    public boolean shouldExceptionsBeIgnored() {
+        return ignoreExceptions;
+    }
 }

--- a/awaitility/src/test/java/com/jayway/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/AwaitilityTest.java
@@ -375,6 +375,25 @@ public class AwaitilityTest {
         }
     }
 
+    @Test(timeout = 2000)
+    public void exceptionsDuringEvaluationAreReportedByDefault() {
+        exception.expect(RuntimeException.class);
+        exception.expectMessage(is("Repository value is not 1"));
+
+        new Asynch(fakeRepository).perform();
+        await().atMost(1000, MILLISECONDS).with().until(conditionsThatIsThrowingAnExceptionForATime());
+    }
+
+    @Test(timeout = 2000)
+    public void exceptionsDuringEvaluationAreIgnoredWhenDeclaredNonFatal() {
+        new Asynch(fakeRepository).perform();
+        await().atMost(1000, MILLISECONDS).with().ignoreExceptions().until(conditionsThatIsThrowingAnExceptionForATime());
+    }
+
+    private Callable<Boolean> conditionsThatIsThrowingAnExceptionForATime() {
+        return new ThrowExceptionUnlessFakeRepositoryEqualsOne(fakeRepository);
+    }
+
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {
         return new FakeRepositoryEqualsOne(fakeRepository);
     }

--- a/awaitility/src/test/java/com/jayway/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/AwaitilityTest.java
@@ -385,10 +385,18 @@ public class AwaitilityTest {
     }
 
     @Test(timeout = 2000)
-    public void exceptionsDuringEvaluationAreIgnoredWhenDeclaredNonFatal() {
+    public void exceptionsDuringEvaluationAreIgnoredUponRequest() {
         new Asynch(fakeRepository).perform();
         await().atMost(1000, MILLISECONDS).with().ignoreExceptions().until(conditionsThatIsThrowingAnExceptionForATime());
     }
+
+    @Test(timeout = 2000)
+    public void exceptionsDuringEvaluationAreIgnoredWhenSetAsDefault() {
+        new Asynch(fakeRepository).perform();
+        Awaitility.ignoreExceptionsByDefault();
+        await().atMost(1000, MILLISECONDS).until(conditionsThatIsThrowingAnExceptionForATime());
+    }
+
 
     private Callable<Boolean> conditionsThatIsThrowingAnExceptionForATime() {
         return new ThrowExceptionUnlessFakeRepositoryEqualsOne(fakeRepository);

--- a/awaitility/src/test/java/com/jayway/awaitility/ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest.java
@@ -1,0 +1,35 @@
+package com.jayway.awaitility;
+
+import com.jayway.awaitility.classes.Asynch;
+import com.jayway.awaitility.classes.FakeRepository;
+import com.jayway.awaitility.classes.FakeRepositoryImpl;
+import com.jayway.awaitility.classes.ThrowExceptionUnlessFakeRepositoryEqualsOne;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+public class ExceptionsInSetupAreIgnoredWhenIgnoreExceptionsIsActiveTest {
+
+    private static FakeRepository fakeRepository = new FakeRepositoryImpl();
+
+    @BeforeClass
+    public static void exceptionThrowingSetupStep() {
+        new Asynch(fakeRepository).perform();
+        Awaitility
+                .with().ignoreExceptions()
+                .await().atMost(1000, TimeUnit.MILLISECONDS).until(
+                    conditionsThatIsThrowingAnExceptionForATime()
+                );
+    }
+
+    private static Callable<Boolean> conditionsThatIsThrowingAnExceptionForATime() {
+        return new ThrowExceptionUnlessFakeRepositoryEqualsOne(fakeRepository);
+    }
+
+    @Test
+    public void exceptionsInTestSetupAreIgnoredWhenIgnoringExceptions() {
+        // nothing here, test logic sits in @BeforeClass method
+    }
+}

--- a/awaitility/src/test/java/com/jayway/awaitility/classes/ThrowExceptionUnlessFakeRepositoryEqualsOne.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/classes/ThrowExceptionUnlessFakeRepositoryEqualsOne.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.jayway.awaitility.classes;
+
+import java.util.concurrent.Callable;
+
+public class ThrowExceptionUnlessFakeRepositoryEqualsOne implements Callable<Boolean> {
+
+    private final FakeRepository repository;
+
+    public ThrowExceptionUnlessFakeRepositoryEqualsOne(FakeRepository repository) {
+        super();
+        this.repository = repository;
+    }
+
+    public Boolean call() {
+        if (repository.getValue() != 1) {
+            throw new RuntimeException("Repository value is not 1");
+        }
+        return true;
+    }
+}
+


### PR DESCRIPTION
This adds option `ignoreExceptions`, which treats Exceptions that occur during condition evaluation as non-fatal, evaluating to `false`. This helped us cover a use case where we did RestAssured statements, which threw exceptions during the period asserts on the path failed, before settling into boolean values.