### PR TITLE
Add the ability to await for event happening more than once

### DIFF
--- a/awaitility/src/main/java/com/jayway/awaitility/Awaitility.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/Awaitility.java
@@ -20,6 +20,8 @@ import com.jayway.awaitility.pollinterval.FixedPollInterval;
 import com.jayway.awaitility.pollinterval.PollInterval;
 import org.hamcrest.Matcher;
 
+import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 
 import static com.jayway.awaitility.Duration.ONE_HUNDRED_MILLISECONDS;
@@ -475,6 +477,10 @@ public class Awaitility {
                 }
             }
         };
+    }
+
+    public static <T> Callable<List<T>> happens(Callable<T> callable, Matcher<T> matcher) {
+        return new AggregatingCallable<T>(callable, matcher);
     }
 
     /**

--- a/awaitility/src/main/java/com/jayway/awaitility/core/AggregatingCallable.java
+++ b/awaitility/src/main/java/com/jayway/awaitility/core/AggregatingCallable.java
@@ -1,0 +1,27 @@
+package com.jayway.awaitility.core;
+
+import org.hamcrest.Matcher;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class AggregatingCallable<T> implements Callable<List<T>> {
+
+    private final List<T> collectedResults = new CopyOnWriteArrayList<T>();
+    private final Callable<T> callable;
+    private final Matcher<T> matcher;
+
+    public AggregatingCallable(Callable<T> callable, Matcher<T> matcher) {
+        this.callable = callable;
+        this.matcher = matcher;
+    }
+
+    public List<T> call() throws Exception {
+        T result = callable.call();
+        if (matcher.matches(result)) {
+            collectedResults.add(result);
+        }
+        return collectedResults;
+    }
+}

--- a/awaitility/src/test/java/com/jayway/awaitility/AwaitilityTest.java
+++ b/awaitility/src/test/java/com/jayway/awaitility/AwaitilityTest.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -430,6 +431,21 @@ public class AwaitilityTest {
                            }
                        }
                 );
+    }
+
+    @Test(timeout = 2000L)
+    public void aggregatesResultsInCallable() {
+        List<String> result = await().atMost(1, TimeUnit.SECONDS)
+                .until(happens(new Callable<String>() {
+                    private final List<String> answers = Arrays.asList("first", "second", "third");
+                    private int index;
+
+                    public String call() throws Exception {
+                        return answers.get(index++);
+                    }
+                }, not(isEmptyString())), hasSize(3));
+        assertThat(result, hasSize(3));
+        assertThat(result, hasItems("first", "second", "third"));
     }
 
     private Callable<Boolean> fakeRepositoryValueEqualsOne() {


### PR DESCRIPTION
It would be nice to have a built-in feature that will allow awaiting for some event happening more than once. For example, I'm sending three messages to the queue and expecting that they all three will be received at some point in time.

    for (Message message : messages) {
        sendMessageToTheQueue(message);
    }

    List<Message> messages = await().until(receiveMessage(), hasMyId(), times(3));

    ...
    Callable<Message> receiveMessage();
    Matcher<Message> hasMyId();