### PR TITLE
Groovy extension module

### DIFF
--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
     </dependencies>
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -26,6 +26,7 @@
     <description>Simplifies Awaitility usage from Groovy</description>
     <properties>
         <groovy.version>2.4.4</groovy.version>
+        <spock.version>1.0-groovy-2.4</spock.version>
         <gmaven.version>1.5</gmaven.version>
     </properties>
     <dependencies>
@@ -36,7 +37,7 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>0.7-groovy-2.0</version>
+            <version>${spock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/awaitility-groovy/pom.xml
+++ b/awaitility-groovy/pom.xml
@@ -54,6 +54,15 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <forkCount>1</forkCount>
+                    <reuseForks>false</reuseForks>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.codehaus.gmaven</groupId>
                 <artifactId>gmaven-plugin</artifactId>
                 <version>${gmaven.version}</version>

--- a/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModule.groovy
+++ b/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModule.groovy
@@ -1,5 +1,5 @@
 /*
-* Copyright 2014 the original author or authors.
+* Copyright 2016 the original author or authors.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -21,21 +21,15 @@ import java.util.concurrent.Callable
 
 import static com.jayway.awaitility.spi.Timeout.timeout_message
 
-@Deprecated
-class AwaitilityGroovyBridge {
+class AwaitilityExtensionModule {
 
-  static void initializeAwaitilityGroovySupport() {
+  static {
     timeout_message = "Condition was not fulfilled"
-
-    def originalMethod = ConditionFactory.metaClass.getMetaMethod("until", Runnable.class)
-    ConditionFactory.metaClass.until { Runnable runnable ->
-      if (runnable instanceof Closure) {
-        delegate.until(runnable as Callable<Boolean>)
-      } else {
-        originalMethod.invoke(delegate, runnable)
-      }
-      // Return true to signal that everything went OK (for spock tests)
-      true
-    }
   }
+
+  static <T> T until(ConditionFactory self, Closure<T> closure) {
+    self.until(closure as Callable<Boolean>)
+    closure()
+  }
+
 }

--- a/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModule.groovy
+++ b/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModule.groovy
@@ -15,6 +15,7 @@
 */
 package com.jayway.awaitility.groovy
 
+import com.jayway.awaitility.core.AssertionCondition
 import com.jayway.awaitility.core.ConditionFactory
 
 import java.util.concurrent.Callable
@@ -27,9 +28,13 @@ class AwaitilityExtensionModule {
     timeout_message = "Condition was not fulfilled"
   }
 
-  static <T> T until(ConditionFactory self, Closure<T> closure) {
-    self.until(closure as Callable<Boolean>)
-    closure()
+  static def until(ConditionFactory self, Runnable runnable) {
+    if (runnable instanceof Callable)
+      self.until(runnable as Callable)
+    else
+      self.until(new AssertionCondition(runnable, self.generateConditionSettings()))
+    // Return true to signal that everything went OK (for spock tests)
+    return true
   }
 
 }

--- a/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityGroovyBridge.groovy
+++ b/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityGroovyBridge.groovy
@@ -29,11 +29,7 @@ class AwaitilityGroovyBridge {
     def originalMethod = ConditionFactory.metaClass.getMetaMethod("until", Runnable.class)
     ConditionFactory.metaClass.until { Runnable runnable ->
       if (runnable instanceof Closure) {
-        delegate.until(new Callable<Boolean>() {
-          Boolean call() {
-            return (runnable as Closure).call();
-          }
-        });
+        delegate.until(runnable as Callable<Boolean>)
       } else {
         originalMethod.invoke(delegate, runnable)
       }

--- a/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilitySupport.groovy
+++ b/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilitySupport.groovy
@@ -17,6 +17,7 @@ package com.jayway.awaitility.groovy
 
 import com.jayway.awaitility.Awaitility
 
+@Deprecated
 class AwaitilitySupport extends Awaitility {
 
   AwaitilitySupport() {

--- a/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityTrait.groovy
+++ b/awaitility-groovy/src/main/groovy/com/jayway/awaitility/groovy/AwaitilityTrait.groovy
@@ -15,6 +15,7 @@
 */
 package com.jayway.awaitility.groovy
 
+@Deprecated
 trait AwaitilityTrait {
   private Initializer initializer = new Initializer()
 

--- a/awaitility-groovy/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
+++ b/awaitility-groovy/src/main/resources/META-INF/services/org.codehaus.groovy.runtime.ExtensionModule
@@ -1,0 +1,17 @@
+# Copyright 2016 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+moduleName = Awaitility
+moduleVersion = ${project.version}
+extensionClasses = com.jayway.awaitility.groovy.AwaitilityExtensionModule

--- a/awaitility-groovy/src/test/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModuleGroovyTest.groovy
+++ b/awaitility-groovy/src/test/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModuleGroovyTest.groovy
@@ -1,0 +1,66 @@
+/*
+* Copyright 2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.jayway.awaitility.groovy
+
+import com.jayway.awaitility.core.ConditionTimeoutException
+import com.jayway.awaitility.groovy.classes.Asynch
+import spock.lang.Specification
+
+import static com.jayway.awaitility.Awaitility.await
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static org.hamcrest.Matchers.equalTo
+import static org.junit.Assert.assertThat
+
+class AwaitilityExtensionModuleGroovyTest extends Specification {
+
+  def asynch = new Asynch()
+
+  def "groovy closure support should work"() {
+    when: asynch.perform()
+    then: await().until { asynch.getValue() == 1 }
+  }
+
+  def "groovy closure runnable should work in spock"() {
+    when: asynch.perform()
+    then: await().until(new Runnable() {
+
+      @Override
+      void run() {
+        assertThat(asynch.getValue(), equalTo(1))
+      }
+    });
+  }
+
+  def "timeout messages shouldn't contain anonymous class details"() {
+    when:
+    asynch.perform()
+    await().atMost(500, MILLISECONDS).until { asynch.getValue() == 2 }
+
+    then:
+    ConditionTimeoutException e = thrown()
+    e.message == "Condition was not fulfilled within 500 milliseconds."
+  }
+
+  def "await alias should be preserved in timeout messages"() {
+    when:
+    asynch.perform()
+    await("groovy").atMost(500, MILLISECONDS).until { asynch.getValue() == 2 }
+
+    then:
+    ConditionTimeoutException e = thrown()
+    e.message == "Condition with alias 'groovy' didn't complete within 500 milliseconds because condition was not fulfilled."
+  }
+}

--- a/awaitility-groovy/src/test/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModuleTest.groovy
+++ b/awaitility-groovy/src/test/groovy/com/jayway/awaitility/groovy/AwaitilityExtensionModuleTest.groovy
@@ -1,0 +1,72 @@
+/*
+* Copyright 2016 the original author or authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package com.jayway.awaitility.groovy
+
+import com.jayway.awaitility.core.ConditionTimeoutException
+import com.jayway.awaitility.groovy.classes.Asynch
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.ExpectedException
+
+import static com.jayway.awaitility.Awaitility.await
+import static java.util.concurrent.TimeUnit.MILLISECONDS
+import static org.hamcrest.Matchers.equalTo
+import static org.junit.Assert.assertThat
+
+class AwaitilityExtensionModuleTest {
+
+  @Rule
+  public def ExpectedException exception = ExpectedException.none()
+
+  @Test
+  def void groovyClosureSupport() {
+    def asynch = new Asynch().perform()
+
+    await().until { asynch.getValue() == 1 }
+  }
+
+  @Test
+  def void groovyRunnableSupport() {
+    def asynch = new Asynch().perform()
+
+    await().until(new Runnable() {
+      @Override
+      void run() {
+        assertThat(asynch.getValue(), equalTo(1))
+      }
+    });
+  }
+
+  @Test
+  def void timeoutMessagesDoesntContainAnonymousClassDetails() {
+    exception.expect ConditionTimeoutException
+    exception.expectMessage "Condition was not fulfilled within 500 milliseconds"
+
+    def asynch = new Asynch().perform()
+
+    await().atMost(500, MILLISECONDS).until { asynch.getValue() == 2 }
+  }
+
+  @Test
+  def void awaitWithAlias() {
+    exception.expect ConditionTimeoutException
+    exception.expectMessage "Condition with alias 'groovy' didn't complete within 500 milliseconds"
+
+    def asynch = new Asynch().perform()
+
+    await("groovy").atMost(500, MILLISECONDS).until { asynch.getValue() == 2 }
+  }
+}


### PR DESCRIPTION
Both AwaitilitySupport (meant to be used as @Mixin) and
AwaitilityTrait (meant to be implemented) have one big flaw. When not used
for one test class, these test cases might or might not fail, depending on
execution order.

The AwaitilityExtensionModule will automatically add a new method
until(Closure) to the ConditionFactory. So with groovy 2 and above, there
is effectively no need any more to use AwaitilitySupport, AwaitilityTrait
or AwaitilityGroovyBridge. All you need to do is add awaitility-groovy
to your classpath and you are good.

The first implementation overloading until(Closure) did not work. I think this has the same reason as described in http://stackoverflow.com/questions/26037514/groovy-method-overloading-selection-of-method-prefers-interfaces-over-subclasse. Therefore I chose to overwrite the until(Runnable) method and dispatching to the method until(Condition). This method is private, but that is no problem (for now -- but I don't know if this will stay this way) for Groovy.

What do you think?