### PR TITLE
[Scala] Added support for `await until` for Runnable and Callable with Matcher

### DIFF
--- a/awaitility-scala/src/main/scala/com/jayway/awaitility/scala/AwaitilitySupport.scala
+++ b/awaitility-scala/src/main/scala/com/jayway/awaitility/scala/AwaitilitySupport.scala
@@ -33,6 +33,12 @@ trait AwaitilitySupport {
       def call(): java.lang.Boolean = function
     }
   }
+
+  implicit def byNameFunctionToRunnable[T](function: => T): Runnable = {
+    new Runnable {
+      def run(): Unit = function
+    }
+  }
 }
 
 

--- a/awaitility-scala/src/main/scala/com/jayway/awaitility/scala/AwaitilitySupport.scala
+++ b/awaitility-scala/src/main/scala/com/jayway/awaitility/scala/AwaitilitySupport.scala
@@ -22,9 +22,15 @@ import com.jayway.awaitility.spi.Timeout._
 trait AwaitilitySupport {
   timeout_message = "Condition was not fulfilled"
 
-  implicit def byNameFunctionToCallable(function : => scala.Boolean) : Callable[java.lang.Boolean] = {
+  implicit def byNameFunctionToCallableOfType[T](function: => T): Callable[T] = {
+    new Callable[T] {
+      def call(): T = function
+    }
+  }
+
+  implicit def byNameFunctionToCallableOfBoolean(function: => scala.Boolean): Callable[java.lang.Boolean] = {
     new Callable[java.lang.Boolean] {
-      def call() : java.lang.Boolean = function
+      def call(): java.lang.Boolean = function
     }
   }
 }

--- a/awaitility-scala/src/test/scala/com/jayway/awaitility/scala/AwaitilitySupportTest.scala
+++ b/awaitility-scala/src/test/scala/com/jayway/awaitility/scala/AwaitilitySupportTest.scala
@@ -21,6 +21,7 @@ import com.jayway.awaitility.Awaitility._
 import com.jayway.awaitility.core.ConditionTimeoutException
 import org.hamcrest.CoreMatchers
 import org.hamcrest.CoreMatchers.is
+import org.hamcrest.Matchers.{containsString, endsWith, startsWith}
 import org.junit.Assert._
 import org.junit._
 
@@ -70,7 +71,31 @@ class AwaitilitySupportTest extends AwaitilitySupport {
       fail("Expected timeout exception")
     } catch {
         case e : ConditionTimeoutException =>
-          assertEquals("Condition with alias 'scala' didn't complete within 500 milliseconds because com.jayway.awaitility.scala.AwaitilitySupport$$anon$2 expected <true> but was <false>.", e getMessage)
+          assertThat(e getMessage, startsWith("Condition with alias 'scala' didn't complete within 500 milliseconds because"))
+          assertThat(e getMessage, endsWith(" expected <true> but was <false>."))
+    }
+  }
+
+  @Test
+  def functionAsRunnable() {
+    val c1 = new Counter()
+    val c2 = new Counter()
+
+    await until { assertThat(c1.count() + c2.count(),  is(6)) }
+    await until { assertThat(isDone(), is(true)) }
+    await until { assertThat(isDone, CoreMatchers is true)  }
+  }
+
+  @Test
+  def awaitWithAliasAndRunnable() = {
+    try {
+      await("scala") atMost(500, MILLISECONDS) until { assertThat(2 == 1, is(true))}
+      fail("Expected timeout exception")
+    } catch {
+        case e : ConditionTimeoutException =>
+          assertThat(e getMessage, startsWith("Condition with alias 'scala' didn't complete within 500 milliseconds because"))
+          assertThat(e getMessage, containsString("Expected: is <true>"))
+          assertThat(e getMessage, endsWith("but: was <false>."))
     }
   }
 

--- a/awaitility-scala/src/test/scala/com/jayway/awaitility/scala/AwaitilitySupportTest.scala
+++ b/awaitility-scala/src/test/scala/com/jayway/awaitility/scala/AwaitilitySupportTest.scala
@@ -19,6 +19,8 @@ import java.util.concurrent.TimeUnit.MILLISECONDS
 
 import com.jayway.awaitility.Awaitility._
 import com.jayway.awaitility.core.ConditionTimeoutException
+import org.hamcrest.CoreMatchers
+import org.hamcrest.CoreMatchers.is
 import org.junit.Assert._
 import org.junit._
 
@@ -48,6 +50,27 @@ class AwaitilitySupportTest extends AwaitilitySupport {
     } catch {
         case e : ConditionTimeoutException =>
           assertEquals("Condition with alias 'scala' didn't complete within 500 milliseconds because condition was not fulfilled.", e getMessage)
+    }
+  }
+
+  @Test
+  def functionAsSupplierWithMatcher() {
+    val c1 = new Counter()
+    val c2 = new Counter()
+
+    await until (c1.count() + c2.count(),  is(6))
+    await until (isDone(), is(java.lang.Boolean.TRUE))
+    await until (isDone, CoreMatchers is java.lang.Boolean.TRUE )
+  }
+
+  @Test
+  def awaitWithAliasSupplierAndMatcher() = {
+    try {
+      await("scala") atMost(500, MILLISECONDS) until (2 == 1, is(java.lang.Boolean.TRUE))
+      fail("Expected timeout exception")
+    } catch {
+        case e : ConditionTimeoutException =>
+          assertEquals("Condition with alias 'scala' didn't complete within 500 milliseconds because com.jayway.awaitility.scala.AwaitilitySupport$$anon$2 expected <true> but was <false>.", e getMessage)
     }
   }
 

--- a/awaitility-scala/src/test/scala/com/jayway/awaitility/scala/AwaitilitySupportTest.scala
+++ b/awaitility-scala/src/test/scala/com/jayway/awaitility/scala/AwaitilitySupportTest.scala
@@ -60,10 +60,4 @@ class AwaitilitySupportTest extends AwaitilitySupport {
     }
 
     def isDone() : Boolean = true
-
-    var c = 0
-    def count() = {
-      c = c + 1
-      c
-    }
 }


### PR DESCRIPTION
This is to add additional conversions to make more of the standard syntax easier to read in Scala.
This is following current conventions in the production and test code.
Please let me know if you'd like me to improve anything!